### PR TITLE
Do not capture term in scraper

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -21,12 +21,10 @@ end
 ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
 
 url = 'http://www.alderney.gov.gg/article/4077/States-Members'
-term = 2014
 data = (scrape url => MembersPage).member_urls.map do |mem_url|
   (scrape mem_url => MemberPage).to_h.merge(district: 'Alderney',
-                                            party:    'Independent',
-                                            term:     term)
+                                            party:    'Independent')
 end
 
 # data.each { |d| puts d.reject { |_k, v| v.to_s.empty? }.sort_by { |k, _v| k }.to_h }
-ScraperWiki.save_sqlite(%i(id term), data)
+ScraperWiki.save_sqlite(%i(id), data)


### PR DESCRIPTION
This is a step towards importing the new 'term'. Part of: https://github.com/everypolitician/everypolitician-data/issues/25302 

The legislature does not have distinct terms.

_"Elections in Alderney are held for the positions both of President and Member of the States of Alderney. The President of the States of Alderney is directly elected every four years. Half of the ten States Members are elected every two years for a four-year mandate."_ https://en.wikipedia.org/wiki/Elections_in_Alderney

As there are no set terms, the scraper does not need to record a term name.

(For EP purposes, the term can be set in the import query.)